### PR TITLE
Added live rested XP update while online

### DIFF
--- a/GryllsExpBar.lua
+++ b/GryllsExpBar.lua
@@ -329,6 +329,7 @@ end
 GryllsExpBar:RegisterEvent("ADDON_LOADED")
 GryllsExpBar:RegisterEvent("PLAYER_ENTERING_WORLD")
 GryllsExpBar:RegisterEvent("PLAYER_XP_UPDATE")
+GryllsExpBar:RegisterEvent("UPDATE_EXHAUSTION")
 GryllsExpBar:RegisterEvent("UPDATE_FACTION")
 GryllsExpBar:SetScript("OnEvent", function()
 	if event == "ADDON_LOADED" then
@@ -345,7 +346,7 @@ GryllsExpBar:SetScript("OnEvent", function()
     elseif event == "PLAYER_ENTERING_WORLD" then
         updateExp()
         updateRep()
-    elseif event == "PLAYER_XP_UPDATE" then
+    elseif event == "PLAYER_XP_UPDATE" or event == "UPDATE_EXHAUSTION" then
         updateExp()
     elseif event == "UPDATE_FACTION" then
         updateRep()


### PR DESCRIPTION
While gaining rested experience while online, one would have to reload the UI for the bar to show the actual rested experience. This fixes that by listening to the rested XP update event.